### PR TITLE
Return zone if projection is UTM.

### DIFF
--- a/read_write_grids/read_geotif.m
+++ b/read_write_grids/read_geotif.m
@@ -4,8 +4,13 @@ function sData = read_geotif(pathData, varLd, lonLd, latLd, fr, cropType)
 sData = struct;
 
 %METHOD USING 'geoimread' (From File Exchange)
-[sData.(varLd),sData.longitude,sData.latitude,~] = geoimread(pathData);
+[sData.(varLd),sData.longitude,sData.latitude,I] = geoimread(pathData);
     sData.latitude = sData.latitude(:);
+    
+%If geotiff is in UTM, get UTM zone
+if regexpbl(I.Projection, 'UTM')
+    sData.utmZone = sprintf('%02d %s', I.Zone, I.Projection(end:end));
+end
 
 %Crop:
 if all(~isnan(lonLd)) && all(~isnan(latLd))


### PR DESCRIPTION
Returned structure now includes zone string if projection is UTM.
String is in form of 2-digit number, space and letter, which is
what is required by utm2deg function.