### PR TITLE
Fixes fitness bug that was crashing for Parajke stat on dDEM obs.

### DIFF
--- a/general/fitness.m
+++ b/general/fitness.m
@@ -296,6 +296,18 @@ for mm = 1 : nFit
 
         %Find number of pixels that are glaciated or have permanent snow cover
         %(i.e. always 100 or nan in MODIS observations)
+        %If obs are only 2D, force a degenerate 3rd dim so the rest of the
+        %indexing works; this is safe to do for both obs and mod
+        %because their dims are checked earlier and forced to be the same
+        if numel(size(obs)) == 2
+            szGrid = size(obs);
+            obs = reshape(obs, 1, szGrid(1), szGrid(2));
+            mod = reshape(mod, 1, szGrid(1), szGrid(2));
+            orig2dim = true;
+    
+        else
+            orig2dim = false;
+        end
         szGrid = size(squeeze(obs(1,:,:)));
         subGlac = zeros(prod(szGrid),1, 'single');
 
@@ -376,6 +388,13 @@ for mm = 1 : nFit
         else
             statOut(mm) = wghtOvr*EOvrAvg + wghtUnd*EUndAvg;
         end
+        
+        % If original obs/mod were 2D, remove the degenerate dimension
+        if orig2dim
+            obs = squeeze(obs);
+            mod = squeeze(mod);
+        end
+        
     else
         error('fitness:unknownMetric',['The fitness evaluation metric ' strEval{mm} ' has not been programmed for.']);
     end

--- a/general/fitness.m
+++ b/general/fitness.m
@@ -303,10 +303,6 @@ for mm = 1 : nFit
             szGrid = size(obs);
             obs = reshape(obs, 1, szGrid(1), szGrid(2));
             mod = reshape(mod, 1, szGrid(1), szGrid(2));
-            orig2dim = true;
-    
-        else
-            orig2dim = false;
         end
         szGrid = size(squeeze(obs(1,:,:)));
         subGlac = zeros(prod(szGrid),1, 'single');
@@ -387,12 +383,6 @@ for mm = 1 : nFit
             statOut(mm) = wghtUnd*EUndAvg;
         else
             statOut(mm) = wghtOvr*EOvrAvg + wghtUnd*EUndAvg;
-        end
-        
-        % If original obs/mod were 2D, remove the degenerate dimension
-        if orig2dim
-            obs = squeeze(obs);
-            mod = squeeze(mod);
         end
         
     else


### PR DESCRIPTION
Parajke processing assumes 3 dimensions in obs data, which works
fine for MODIS (time, rows, cols) but was causing an error in the
call to sub2ind due to incorrect indexing when dDEM obs (rows,
cols) were being compared.  In this case, have temporarily forced
a degenerate 3rd dimension of 1 (time step) so that indexing is
done correctly.

Note that call to squeeze for mod and obs at end will squeeze all
dimensions of size 1, so if there is ever a case where a vector
is input, the resulting obs and mod arrays may be squeezed too far.